### PR TITLE
add nodezator app in "FLOSS + Python..." list

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ After updating a few times the data from the earlier table, work started on comp
 - [Pero](https://github.com/xxao/pero) — A unified Python API for multiple drawing backends. 
 - [generativepy](https://github.com/martinmcbride/generativepy) — Generative art and graphing library based on PyCairo.
 - [vsketch](https://github.com/abey79/vsketch) — A plotter-centric Python generative art toolkit. 
+- [nodezator](https://github.com/IndiePython/nodezator) — A multi-purpose visual node editor for Python with visualization capabilities.
 
 ----
 


### PR DESCRIPTION
Dear Mr. Villares,

I'm Kennedy Guerra, creator and maintainer of the [Nodezator app](https://github.com/IndiePython/nodezator), a multi-purpose node editor for the Python programming language. I believe the addition of my app to list of **FLOSS + Python options to explore** in the README file of your repository is relevant considering the purposes/nature of your repo (sharing programming tools for artists, designers and architects).

Nodezator offers a visual node-based environment where people can create and execute graphs with Python functions/callables and its new version 1.4 added even more visualization capabilities to it, as can be briefly previewed in this video: https://www.youtube.com/watch?v=gYC8_JCZo84

Also, Nodezator is completely free of charge and in the public domain, no registrations/subscriptions required. Because it can turn any Python callable into a node, it integrates well with virtually any Python library. Here's a recent post on the [r/Python](https://reddit.com/r/Python) subreddit describing its new capabilities: https://www.reddit.com/r/Python/comments/167ax2w/nodezator_v14_released_python_node_editor_in_the/

Please, let me know if you need to anything else or if this pull request is somehow inappropriate.

Peace